### PR TITLE
Parse crpf version field

### DIFF
--- a/parser/src/crpf/mod.rs
+++ b/parser/src/crpf/mod.rs
@@ -6,6 +6,7 @@ use crate::types::{CrpfGuid, Guid, PrimitiveType};
 mod read;
 
 const CRPF_MAGIC: u32 = 0x46505243;
+const CRPF_VERSION: u32 = 2;
 const CTCB_MAGIC: u32 = 0x42435443;
 const KBF_MAGIC: u32 = 0x3046424B;
 
@@ -29,7 +30,7 @@ pub struct Crpf {
 pub struct CrpfHeader {
     pub magic: u32,
 
-    pub unk0: u32, // 2
+    pub version: u32, // 2
     pub unk1: u32, // 0
     pub unk2: u32, // 0
 

--- a/parser/src/crpf/read.rs
+++ b/parser/src/crpf/read.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::io::{Read, Seek, SeekFrom};
 use shared::io::Reader;
-use crate::crpf::{Crpf, CRPF_MAGIC, CrpfHeader, Ctcb, CTCB_MAGIC, CtcbFieldInfo, CtcbHeader, CtcbNamespace, CtcbTypeEntry, Kbf, KBF_MAGIC, KbfHeader};
+use crate::crpf::{Crpf, CRPF_MAGIC, CRPF_VERSION, CrpfHeader, Ctcb, CTCB_MAGIC, CtcbFieldInfo, CtcbHeader, CtcbNamespace, CtcbTypeEntry, Kbf, KBF_MAGIC, KbfHeader};
 use crate::error::{CrpfError, ParseError};
 use crate::types::{CrpfGuid, Guid, PrimitiveType};
 
@@ -65,7 +65,13 @@ impl CrpfHeader {
             return Err(CrpfError::InvalidMagic(magic).into());
         }
 
-        let unk0 = reader.read_u32()?;
+        let version = reader.read_u32()?;
+
+        // Only support this version for now.
+        if version != CRPF_VERSION {
+            return Err(CrpfError::InvalidVersion(version).into());
+        }
+
         let unk1 = reader.read_u32()?;
         let unk2 = reader.read_u32()?;
 
@@ -84,7 +90,7 @@ impl CrpfHeader {
 
         Ok(Self {
             magic,
-            unk0,
+            version,
             unk1,
             unk2,
             guid_offset,

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -24,6 +24,8 @@ pub enum ParseError {
 pub enum CrpfError {
     #[error("Invalid magic number: {0:X}")]
     InvalidMagic(u32),
+    #[error("Invalid version number: {0:X}")]
+    InvalidVersion(u32),
     #[error("Invalid kbf magic number: {0:X}")]
     InvalidKBFMagic(u32),
     #[error("Invalid CTCB magic number: {0:X}")]


### PR DESCRIPTION
Parses the version field from the CRPF header.

The game client specifically checks for version==`2` and will fail with an error message about the wrong version if not.