### PR TITLE
kfc-base: fall back to existing bundle entries on unknown type

### DIFF
--- a/crates/kfc-base/src/container/file.rs
+++ b/crates/kfc-base/src/container/file.rs
@@ -142,7 +142,27 @@ impl KFCFile {
     ) {
         self.resources = resources;
         self.resource_locations[0].count = self.resources.len();
-        self.rebuild_resource_bundles(type_registry);
+        self.rebuild_resource_bundles(type_registry, None);
+    }
+
+    /// Same as [`Self::set_resources`], but consults `fallback` for the
+    /// `internal_hash` of any resource type that is not present in
+    /// `type_registry`.
+    ///
+    /// This is useful for incremental writers: when a game update introduces
+    /// new resource types whose reflection data isn't yet modelled by the
+    /// extractor, the writer can pass the reference (pre-edit) file's
+    /// `resource_bundles` as a fallback so the rebuilt bundles preserve the
+    /// original `internal_hash` for unknown types instead of panicking.
+    pub fn set_resources_with_fallback(
+        &mut self,
+        resources: StaticMap<ResourceId, ResourceEntry>,
+        type_registry: &TypeRegistry,
+        fallback: &StaticMap<Hash32, ResourceBundleEntry>,
+    ) {
+        self.resources = resources;
+        self.resource_locations[0].count = self.resources.len();
+        self.rebuild_resource_bundles(type_registry, Some(fallback));
     }
 
     pub fn set_resource_chunks(
@@ -176,7 +196,11 @@ impl KFCFile {
         self.version = version;
     }
 
-    fn rebuild_resource_bundles(&mut self, type_registry: &TypeRegistry) {
+    fn rebuild_resource_bundles(
+        &mut self,
+        type_registry: &TypeRegistry,
+        fallback: Option<&StaticMap<Hash32, ResourceBundleEntry>>,
+    ) {
         let mut type_hashes = self
             .resources
             .keys()
@@ -185,14 +209,28 @@ impl KFCFile {
             .collect::<HashSet<_>>()
             .into_iter()
             .map(|hash| {
+                let internal_hash = type_registry
+                    .get_by_hash(LookupKey::Qualified(hash))
+                    .map(|t| t.internal_hash)
+                    .or_else(|| {
+                        fallback.and_then(|b| b.get(&hash).map(|e| e.internal_hash))
+                    })
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "type {:#010X} not found in type registry{}",
+                            hash,
+                            if fallback.is_some() {
+                                " nor in fallback bundles"
+                            } else {
+                                ""
+                            }
+                        )
+                    });
+
                 (
                     hash,
                     ResourceBundleEntry {
-                        // TODO: Remove unwrap
-                        internal_hash: type_registry
-                            .get_by_hash(LookupKey::Qualified(hash))
-                            .unwrap()
-                            .internal_hash,
+                        internal_hash,
                         ..Default::default()
                     },
                 )

--- a/crates/kfc-base/src/container/writer.rs
+++ b/crates/kfc-base/src/container/writer.rs
@@ -413,7 +413,21 @@ where
         let mut file = KFCFile::default();
 
         file.set_game_version(self.game_version);
-        file.set_resources(self.resources.build(), self.type_registry.borrow());
+        // In incremental mode, pass the reference file's existing resource
+        // bundles as a fallback so types added by newer game versions (whose
+        // reflection data isn't in the loaded type registry) preserve their
+        // original `internal_hash` instead of panicking.
+        match self.incremental_data.as_ref() {
+            Some(data) => file.set_resources_with_fallback(
+                self.resources.build(),
+                self.type_registry.borrow(),
+                data.reference_file.borrow().resource_bundles(),
+            ),
+            None => file.set_resources(
+                self.resources.build(),
+                self.type_registry.borrow(),
+            ),
+        }
         file.set_contents(self.contents.build());
         file.set_containers(containers);
         file.set_resource_chunks(chunks);


### PR DESCRIPTION
DISCLAMER!

Something seems to have broken in the latest major game update and I wanted to play without loosing all the items my "increase stacksize" mod have over-stacked.

So I asked Claude/Cursor to fix it. I have no idea what it did, I have not looked at the codebase and I don´t know if it makes sense. 

But it worked and here it is if you want. otherwise just dismiss

----------------------------------------

// Claude/Cursors message

`KFCFile::rebuild_resource_bundles` used to unwrap the result of `TypeRegistry::get_by_hash(LookupKey::Qualified(..))` to look up the `internal_hash` for every resource type in the map. When a game update introduces resource types whose reflection data isn't captured by the current type registry (extracted from the .exe), this lookup returns `None` and the writer panics at
`crates/kfc-base/src/container/file.rs` during
`KFCWriter::finalize()`, leaving the .kfc/.kfc_resources pair in a partially-written state. In the `dbghelp-proxy` / `dinput8-proxy` runtime path the panic hook pops a `MessageBoxA` which hangs forever in headless Wine environments (e.g. dedicated servers running under `xvfb-run`).

Since the incremental writer already holds a reference to the pre-edit `KFCFile`, its `resource_bundles` map is a sound source of truth for unknown types: a mod that only mutates existing resources never introduces new type hashes, so every type we emit existed in the original file and its bundle entry is valid.

This patch:

- Adds `KFCFile::set_resources_with_fallback`, a non-breaking companion to `set_resources` that accepts a reference bundle map to consult when the type registry lookup misses.
- Threads an `Option<&StaticMap<..>>` through the private `rebuild_resource_bundles` helper; the existing `set_resources` entry point calls it with `None`, preserving current behaviour for non-incremental callers.
- Replaces the bare `.unwrap()` (with its "TODO: Remove unwrap" comment) with a `panic!` that reports the offending type hash and whether a fallback was consulted, making the failure mode debuggable when it does fire.
- Updates `KFCWriter::finalize` to call the fallback variant when the writer was constructed via `new_incremental*`, passing the reference file's `resource_bundles`.

Verified on Enshrouded `ea_update_08` (build id 999467): a runtime mod that patches `keen::ItemInfo::maxStackSize` previously hung the dedicated server during "Applying patches..."; with this change the kfc is written successfully, the server reaches init, and the modded stack sizes are observable in-game.

Made-with: Cursor