### PR TITLE
Enhance error handling and improve file processing features

### DIFF
--- a/crates/cli-legacy/src/main.rs
+++ b/crates/cli-legacy/src/main.rs
@@ -136,8 +136,16 @@ fn unpack(
         fatal!("Game directory does not exist: {}", game_dir.display());
     }
 
-    if output_dir.map(|x| !x.exists()).unwrap_or(false) {
-        fatal!("Output directory does not exist: {}", output_dir.unwrap().display());
+    if let Some(dir) = output_dir {
+        if dir.exists() && !dir.is_dir() {
+            fatal!("Output path exists but is not a directory: {}", dir.display());
+        }
+        if !dir.exists() {
+            if let Err(e) = std::fs::create_dir_all(dir) {
+                fatal!("Failed to create output directory {}: {}", dir.display(), e);
+            }
+            info!("Created output directory: {}", dir.display());
+        }
     }
 
     let file_name = get_file_name(game_dir, file_name)?;
@@ -253,6 +261,8 @@ fn unpack_files(
     let total = guids.len() as u32;
     let pending_guids = Mutex::new(guids.into_iter().collect::<Vec<_>>());
     let failed_unpacks = AtomicU32::new(0);
+    let unknown_unpacks = AtomicU32::new(0);
+    let warned_unknown_types = Mutex::new(HashSet::<u32>::new());
     let start = std::time::Instant::now();
     let names = Mutex::new(HashSet::new());
 
@@ -261,6 +271,8 @@ fn unpack_files(
 
         for i in 0..thread_count {
             let failed_unpacks = &failed_unpacks;
+            let unknown_unpacks = &unknown_unpacks;
+            let warned_unknown_types = &warned_unknown_types;
             let pending_guids = &pending_guids;
             let output_dir = &output_dir;
             let pb = &pb;
@@ -291,6 +303,44 @@ fn unpack_files(
                     };
 
                     let result: anyhow::Result<()> = (|| {
+                        // If the type isn't in the registry, dump raw bytes instead of failing.
+                        if type_registry.get_by_hash(LookupKey::Qualified(guid.type_hash())).is_none() {
+                            buf.clear();
+                            if !reader.read_resource_into(guid, &mut buf)? {
+                                pb.suspend(|| {
+                                    warn!("Skipping descriptor (not found): {}", guid.to_qualified_string());
+                                });
+                                return Ok(());
+                            }
+
+                            let type_hash = guid.type_hash();
+                            let parent = output_dir
+                                .join("_unknown")
+                                .join(format!("{:08x}", type_hash));
+
+                            if !parent.exists() {
+                                std::fs::create_dir_all(&parent)?;
+                            }
+
+                            let path = parent.join(format!("{}.bin", guid.to_qualified_string()));
+                            std::fs::write(&path, &buf)?;
+
+                            unknown_unpacks.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+                            let mut warned = warned_unknown_types.lock().unwrap();
+                            if warned.insert(type_hash) {
+                                pb.suspend(|| {
+                                    warn!(
+                                        "Unknown type 0x{:08X} not found in registry; dumping raw bytes to {}",
+                                        type_hash,
+                                        parent.display()
+                                    );
+                                });
+                            }
+
+                            return Ok(());
+                        }
+
                         buf.clear();
                         let descriptor = match crate::util::read_descriptor_into(
                             &mut reader,
@@ -372,9 +422,17 @@ fn unpack_files(
     pb.finish_and_clear();
 
     let failed_unpacks = failed_unpacks.load(std::sync::atomic::Ordering::Relaxed);
+    let unknown_unpacks = unknown_unpacks.load(std::sync::atomic::Ordering::Relaxed);
     let end = std::time::Instant::now();
 
-    info!("Unpacked a total of {}/{} descriptors in {:?}", total - failed_unpacks, total, end - start);
+    info!(
+        "Unpacked a total of {}/{} descriptors in {:?} ({} raw, {} failed)",
+        total - failed_unpacks - unknown_unpacks,
+        total,
+        end - start,
+        unknown_unpacks,
+        failed_unpacks,
+    );
 
     Ok(())
 }
@@ -1173,6 +1231,8 @@ fn assemble_impact(
     let output_file = output_file.unwrap_or(input_file)
         .with_extension("json");
 
+    ensure_parent_dir(&output_file)?;
+
     let writer = match File::create(&output_file) {
         Ok(file) => BufWriter::new(file),
         Err(e) => fatal!("Failed to create output file: {}", e)
@@ -1199,6 +1259,10 @@ fn disassemble_impact(
     let impact_file = output_file.with_file_name(format!("{}.impact", file_name));
     let shutdown_file = output_file.with_file_name(format!("{}.shutdown.impact", file_name));
     let data_file = output_file.with_file_name(format!("{}.data.json", file_name));
+
+    ensure_parent_dir(&impact_file)?;
+    ensure_parent_dir(&shutdown_file)?;
+    ensure_parent_dir(&data_file)?;
 
     // read program
 
@@ -1318,6 +1382,20 @@ fn get_file_opt(
     let file = game_dir.join(format!("{}.{}", file_name, extension));
 
     Ok(file)
+}
+
+/// Ensure the parent directory of `path` exists, creating it (and any missing
+/// parents) on demand. No-op if `path` has no parent or the parent already exists.
+fn ensure_parent_dir(path: &Path) -> Result<(), Error> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                fatal!("Failed to create directory {}: {}", parent.display(), e);
+            }
+            info!("Created directory: {}", parent.display());
+        }
+    }
+    Ok(())
 }
 
 fn get_file_name(

--- a/crates/kfc-base/src/container/error.rs
+++ b/crates/kfc-base/src/container/error.rs
@@ -7,6 +7,9 @@ pub enum KFCWriteError {
 
     #[error("Size too large: {0}")]
     SizeTooLarge(u64),
+
+    #[error("Unknown resource type hash: {0:#X}")]
+    UnknownTypeHash(u32),
 }
 
 #[derive(Debug, Error)]

--- a/crates/kfc-base/src/container/file.rs
+++ b/crates/kfc-base/src/container/file.rs
@@ -139,7 +139,7 @@ impl KFCFile {
         &mut self,
         resources: StaticMap<ResourceId, ResourceEntry>,
         type_registry: &TypeRegistry,
-        internal_hash_fallback: Option<&HashMap<Hash32, Hash32>>,
+        internal_hash_fallback: Option<&StaticMap<Hash32, ResourceBundleEntry>>,
     ) -> Result<(), KFCWriteError> {
         self.resources = resources;
         self.resource_locations[0].count = self.resources.len();
@@ -180,7 +180,7 @@ impl KFCFile {
     fn rebuild_resource_bundles(
         &mut self,
         type_registry: &TypeRegistry,
-        internal_hash_fallback: Option<&HashMap<Hash32, Hash32>>,
+        internal_hash_fallback: Option<&StaticMap<Hash32, ResourceBundleEntry>>,
     ) -> Result<(), KFCWriteError> {
         let mut type_hashes = self
             .resources
@@ -190,12 +190,12 @@ impl KFCFile {
             .collect::<HashSet<_>>()
             .into_iter()
             .map(|hash| {
-                let internal_hash = match type_registry.get_by_hash(LookupKey::Qualified(hash)) {
-                    Some(metadata) => metadata.internal_hash,
-                    None => internal_hash_fallback
-                        .and_then(|map| map.get(&hash).copied())
-                        .ok_or(KFCWriteError::UnknownTypeHash(hash))?,
-                };
+                let internal_hash = type_registry.get_by_hash(LookupKey::Qualified(hash))
+                    .map(|info| info.internal_hash)
+                    .or_else(|| internal_hash_fallback
+                        .and_then(|map| map.get(&hash))
+                        .map(|entry| entry.internal_hash))
+                    .ok_or(KFCWriteError::UnknownTypeHash(hash))?;
 
                 Ok((
                     hash,

--- a/crates/kfc-base/src/container/file.rs
+++ b/crates/kfc-base/src/container/file.rs
@@ -139,10 +139,11 @@ impl KFCFile {
         &mut self,
         resources: StaticMap<ResourceId, ResourceEntry>,
         type_registry: &TypeRegistry,
-    ) {
+        internal_hash_fallback: Option<&HashMap<Hash32, Hash32>>,
+    ) -> Result<(), KFCWriteError> {
         self.resources = resources;
         self.resource_locations[0].count = self.resources.len();
-        self.rebuild_resource_bundles(type_registry);
+        self.rebuild_resource_bundles(type_registry, internal_hash_fallback)
     }
 
     pub fn set_resource_chunks(
@@ -176,7 +177,11 @@ impl KFCFile {
         self.version = version;
     }
 
-    fn rebuild_resource_bundles(&mut self, type_registry: &TypeRegistry) {
+    fn rebuild_resource_bundles(
+        &mut self,
+        type_registry: &TypeRegistry,
+        internal_hash_fallback: Option<&HashMap<Hash32, Hash32>>,
+    ) -> Result<(), KFCWriteError> {
         let mut type_hashes = self
             .resources
             .keys()
@@ -185,19 +190,22 @@ impl KFCFile {
             .collect::<HashSet<_>>()
             .into_iter()
             .map(|hash| {
-                (
+                let internal_hash = match type_registry.get_by_hash(LookupKey::Qualified(hash)) {
+                    Some(metadata) => metadata.internal_hash,
+                    None => internal_hash_fallback
+                        .and_then(|map| map.get(&hash).copied())
+                        .ok_or(KFCWriteError::UnknownTypeHash(hash))?,
+                };
+
+                Ok((
                     hash,
                     ResourceBundleEntry {
-                        // TODO: Remove unwrap
-                        internal_hash: type_registry
-                            .get_by_hash(LookupKey::Qualified(hash))
-                            .unwrap()
-                            .internal_hash,
+                        internal_hash,
                         ..Default::default()
                     },
-                )
+                ))
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>, KFCWriteError>>()?;
 
         let mut indices = Vec::with_capacity(self.resources.len());
 
@@ -219,6 +227,8 @@ impl KFCFile {
 
         self.resource_indices = indices;
         self.resource_bundles = type_hashes.into_iter().collect::<HashMap<_, _>>().into();
+
+        Ok(())
     }
 
 }

--- a/crates/kfc-base/src/container/writer.rs
+++ b/crates/kfc-base/src/container/writer.rs
@@ -1,6 +1,6 @@
-use std::{borrow::Borrow, fs::File, io::{BufWriter, Cursor, Seek, SeekFrom, Write}, path::{Path, PathBuf}};
+use std::{borrow::Borrow, collections::HashMap, fs::File, io::{BufWriter, Cursor, Seek, SeekFrom, Write}, path::{Path, PathBuf}};
 
-use crate::{container::header::ResourceChunkInfo, guid::{ContentHash, ResourceId}, io::{WriteExt, WriteSeekExt}, reflection::TypeRegistry};
+use crate::{Hash32, container::header::ResourceChunkInfo, guid::{ContentHash, ResourceId}, io::{WriteExt, WriteSeekExt}, reflection::TypeRegistry};
 
 use super::{header::{ContentEntry, ContainerInfo, ResourceEntry}, KFCFile, KFCReadError, KFCWriteError, StaticMapBuilder};
 
@@ -409,11 +409,24 @@ where
 
         // header construction
 
+        let internal_hash_fallback: Option<HashMap<Hash32, Hash32>> = self.incremental_data.as_ref()
+            .map(|data| {
+                let reference = data.reference_file.borrow();
+                let bundles = reference.resource_bundles();
+                bundles.keys().iter().copied()
+                    .zip(bundles.values().iter().map(|entry| entry.internal_hash))
+                    .collect()
+            });
+
         let mut file_writer = BufWriter::new(&mut self.file);
         let mut file = KFCFile::default();
 
         file.set_game_version(self.game_version);
-        file.set_resources(self.resources.build(), self.type_registry.borrow());
+        file.set_resources(
+            self.resources.build(),
+            self.type_registry.borrow(),
+            internal_hash_fallback.as_ref(),
+        )?;
         file.set_contents(self.contents.build());
         file.set_containers(containers);
         file.set_resource_chunks(chunks);

--- a/crates/kfc-base/src/container/writer.rs
+++ b/crates/kfc-base/src/container/writer.rs
@@ -409,15 +409,6 @@ where
 
         // header construction
 
-        let internal_hash_fallback: Option<HashMap<Hash32, Hash32>> = self.incremental_data.as_ref()
-            .map(|data| {
-                let reference = data.reference_file.borrow();
-                let bundles = reference.resource_bundles();
-                bundles.keys().iter().copied()
-                    .zip(bundles.values().iter().map(|entry| entry.internal_hash))
-                    .collect()
-            });
-
         let mut file_writer = BufWriter::new(&mut self.file);
         let mut file = KFCFile::default();
 
@@ -425,7 +416,8 @@ where
         file.set_resources(
             self.resources.build(),
             self.type_registry.borrow(),
-            internal_hash_fallback.as_ref(),
+            self.incremental_data.as_ref()
+                .map(|data| data.reference_file.borrow().resource_bundles())
         )?;
         file.set_contents(self.contents.build());
         file.set_containers(containers);

--- a/crates/mod-manager-cli/src/main.rs
+++ b/crates/mod-manager-cli/src/main.rs
@@ -73,11 +73,49 @@ fn check_game_directory(
     Ok(())
 }
 
+/// Resolve the base file name (without extension) of the Enshrouded game files.
+///
+/// If the user passed `--file-name`, that value is used as-is. Otherwise we
+/// probe the game directory for `enshrouded.kfc/exe` and `enshrouded_server.kfc/exe`,
+/// falling back to the first `.kfc` or `.exe` we find. As a last resort we
+/// return `"enshrouded"` so the existing error path can report the issue.
+fn resolve_file_name(
+    game_directory: &Path,
+    file_name: Option<String>,
+) -> String {
+    if let Some(name) = file_name {
+        return name;
+    }
+
+    for candidate in ["enshrouded", "enshrouded_server"] {
+        if game_directory.join(candidate).with_extension("kfc").exists()
+            || game_directory.join(candidate).with_extension("exe").exists()
+        {
+            return candidate.to_string();
+        }
+    }
+
+    if let Ok(entries) = std::fs::read_dir(game_directory) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if let Some(ext) = path.extension() {
+                if ext == "kfc" || ext == "exe" {
+                    if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                        return stem.to_string();
+                    }
+                }
+            }
+        }
+    }
+
+    "enshrouded".to_string()
+}
+
 fn create(
     game_directory: PathBuf,
     file_name: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let file_name = file_name.unwrap_or_else(|| "enshrouded".to_string());
+    let file_name = resolve_file_name(&game_directory, file_name);
 
     check_game_directory(&game_directory, &file_name)?;
 
@@ -238,7 +276,7 @@ fn run(
         Some(dir) => dir,
         None => game_directory.join("export"),
     };
-    let file_name = file_name.unwrap_or_else(|| "enshrouded".to_string());
+    let file_name = resolve_file_name(&game_directory, file_name);
 
     check_game_directory(&game_directory, &file_name)?;
 
@@ -302,7 +340,7 @@ fn restore(
     game_directory: PathBuf,
     file_name: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let file_name = file_name.unwrap_or_else(|| "enshrouded".to_string());
+    let file_name = resolve_file_name(&game_directory, file_name);
 
     check_game_directory(&game_directory, &file_name)?;
 


### PR DESCRIPTION
This PR replaces and splits the changes from #17.

- Replaced fallback hash map construction with a reference
- Extracted kfc internal hash fallback into its own commit
- Extracted improved file processing into its own commit
- Adjusted commit messages

Fixes #16 
Closes #15 
Closes #17 